### PR TITLE
Fix Animal Harvest and Shearing

### DIFF
--- a/Herbarium/src/BlockEntity/BEGroundBerryPlant.cs
+++ b/Herbarium/src/BlockEntity/BEGroundBerryPlant.cs
@@ -326,6 +326,30 @@ namespace herbarium
                 Api.World.SpawnItemEntity(dropStack, Pos.ToVec3d().Add(0.5, 0.5, 0.5));
             }
 
+            var bbhm = Block.GetBehavior<BlockBehaviorHarvestMultiple>();
+            if (bbhm?.harvestedStacks != null)
+            {
+                for(int i = 0; i < harvestedStacks.Length; i++)
+                {
+                    ItemStack dropStack = bbhm.harvestedStacks[i].GetNextItemStack();
+                    Api.World.SpawnItemEntity(dropStack, Pos.ToVec3d().Add(0.5, 0.5, 0.5));
+                }
+
+                Api.World.PlaySoundAt(bbhm.harvestingSound, Pos.X + 0.5, Pos.Y + 0.5, Pos.Z + 0.5);
+            }
+
+            var bbhmk = Block.GetBehavior<BlockBehaviorHarvestMultipleWithKnife>();
+            if (bbhk?.harvestedStacks != null)
+            {
+                for(int i = 0; i < harvestedStacks.Length; i++)
+                {
+                    ItemStack dropStack = bbhmk.harvestedStacks[i].GetNextItemStack();
+                    Api.World.SpawnItemEntity(dropStack, Pos.ToVec3d().Add(0.5, 0.5, 0.5));
+                }
+
+                Api.World.PlaySoundAt(bbhmk.harvestingSound, Pos.X + 0.5, Pos.Y + 0.5, Pos.Z + 0.5);
+            }
+
 
             Api.World.BlockAccessor.ExchangeBlock(nextBlock.BlockId, Pos);
             MarkDirty(true);

--- a/Herbarium/src/BlockEntity/BEGroundBerryPlant.cs
+++ b/Herbarium/src/BlockEntity/BEGroundBerryPlant.cs
@@ -161,7 +161,6 @@ namespace herbarium
                 if (transitionHoursLeft <= 0)
                 {
                     if (!DoGrow()) return;
-                    transitionHoursLeft = GetHoursForNextStage();
                 }
             }
 
@@ -171,6 +170,7 @@ namespace herbarium
         public override void OnExchanged(Block block)
         {
             base.OnExchanged(block);
+            transitionHoursLeft = GetHoursForNextStage();
             if (Api?.Side == EnumAppSide.Server) UpdateTransitionsFromBlock();
         }
 

--- a/Herbarium/src/BlockEntity/BEHerbariumBerryBush.cs
+++ b/Herbarium/src/BlockEntity/BEHerbariumBerryBush.cs
@@ -18,6 +18,22 @@ namespace herbarium
             MarkDirty(true);
         }
 
+        public override void CheckGrow(float dt)
+        {
+            base.CheckGrow(dt);
+            
+            if (Api.World.Calendar.TotalDays - LastPrunedTotalDays > 9)
+            {
+                Pruned = false;
+            }
+        }
+
+        public override void OnExchanged(Block block)
+        {
+            base.OnExchanged(block);
+            transitionHoursLeft = GetHoursForNextStage();
+        }
+
         public override bool OnTesselation(ITerrainMeshPool mesher, ITesselatorAPI tessThreadTesselator)
         {
             if (Pruned)

--- a/Herbarium/src/BlockEntity/BEHerbariumBerryBush.cs
+++ b/Herbarium/src/BlockEntity/BEHerbariumBerryBush.cs
@@ -22,7 +22,7 @@ namespace herbarium
         {
             base.CheckGrow(dt);
             
-            if (Api.World.Calendar.TotalDays - LastPrunedTotalDays > 9)
+            if (Api.World.Calendar.TotalDays - LastPrunedTotalDays > 3 * API.World.Calendar.DaysPerMonth / growthRateMul)
             {
                 Pruned = false;
             }
@@ -32,6 +32,57 @@ namespace herbarium
         {
             base.OnExchanged(block);
             transitionHoursLeft = GetHoursForNextStage();
+        }
+
+        public override float ConsumeOnePortion(Entity entity)
+        {
+            AssetLocation loc = Block.CodeWithParts("empty");
+            if (!loc.Valid)
+            {
+                Api.World.BlockAccessor.RemoveBlockEntity(Pos);
+                return 0f;
+            }
+
+            Block nextBlock = Api.World.GetBlock(loc);
+            if (nextBlock?.Code == null) return 0f;
+
+            var bbh = Block.GetBehavior<BlockBehaviorHarvestable>();
+            if (bbh?.harvestedStack != null)
+            {
+                ItemStack dropStack = bbh.harvestedStack.GetNextItemStack();
+                Api.World.PlaySoundAt(bbh.harvestingSound, Pos.X + 0.5, Pos.Y + 0.5, Pos.Z + 0.5);
+                Api.World.SpawnItemEntity(dropStack, Pos.ToVec3d().Add(0.5, 0.5, 0.5));
+            }
+
+            var bbhm = Block.GetBehavior<BlockBehaviorHarvestMultiple>();
+            if (bbhm?.harvestedStacks != null)
+            {
+                for(int i = 0; i < harvestedStacks.Length; i++)
+                {
+                    ItemStack dropStack = bbhm.harvestedStacks[i].GetNextItemStack();
+                    Api.World.SpawnItemEntity(dropStack, Pos.ToVec3d().Add(0.5, 0.5, 0.5));
+                }
+
+                Api.World.PlaySoundAt(bbhm.harvestingSound, Pos.X + 0.5, Pos.Y + 0.5, Pos.Z + 0.5);
+            }
+
+            var bbhmk = Block.GetBehavior<BlockBehaviorHarvestMultipleWithKnife>();
+            if (bbhk?.harvestedStacks != null)
+            {
+                for(int i = 0; i < harvestedStacks.Length; i++)
+                {
+                    ItemStack dropStack = bbhmk.harvestedStacks[i].GetNextItemStack();
+                    Api.World.SpawnItemEntity(dropStack, Pos.ToVec3d().Add(0.5, 0.5, 0.5));
+                }
+
+                Api.World.PlaySoundAt(bbhmk.harvestingSound, Pos.X + 0.5, Pos.Y + 0.5, Pos.Z + 0.5);
+            }
+
+
+            Api.World.BlockAccessor.ExchangeBlock(nextBlock.BlockId, Pos);
+            MarkDirty(true);
+
+            return 0.1f;
         }
 
         public override bool OnTesselation(ITerrainMeshPool mesher, ITesselatorAPI tessThreadTesselator)

--- a/Herbarium/src/BlockEntity/BETallBerryBush.cs
+++ b/Herbarium/src/BlockEntity/BETallBerryBush.cs
@@ -120,7 +120,7 @@ namespace herbarium
                 roomness = 0;
             }
 
-            if (Api.World.Calendar.TotalDays - LastPrunedTotalDays > (5 + rand.NextDouble()) * 1.6 / growthRateMul)
+            if (Api.World.Calendar.TotalDays - LastPrunedTotalDays > 3 * API.World.Calendar.DaysPerMonth / growthRateMul)
             {
                 Pruned = false;
             }
@@ -373,6 +373,30 @@ namespace herbarium
                 ItemStack dropStack = bbh.harvestedStack.GetNextItemStack();
                 Api.World.PlaySoundAt(bbh.harvestingSound, Pos.X + 0.5, Pos.Y + 0.5, Pos.Z + 0.5);
                 Api.World.SpawnItemEntity(dropStack, Pos.ToVec3d().Add(0.5, 0.5, 0.5));
+            }
+
+            var bbhm = Block.GetBehavior<BlockBehaviorHarvestMultiple>();
+            if (bbhm?.harvestedStacks != null)
+            {
+                for(int i = 0; i < harvestedStacks.Length; i++)
+                {
+                    ItemStack dropStack = bbhm.harvestedStacks[i].GetNextItemStack();
+                    Api.World.SpawnItemEntity(dropStack, Pos.ToVec3d().Add(0.5, 0.5, 0.5));
+                }
+
+                Api.World.PlaySoundAt(bbhm.harvestingSound, Pos.X + 0.5, Pos.Y + 0.5, Pos.Z + 0.5);
+            }
+
+            var bbhmk = Block.GetBehavior<BlockBehaviorHarvestMultipleWithKnife>();
+            if (bbhk?.harvestedStacks != null)
+            {
+                for(int i = 0; i < harvestedStacks.Length; i++)
+                {
+                    ItemStack dropStack = bbhmk.harvestedStacks[i].GetNextItemStack();
+                    Api.World.SpawnItemEntity(dropStack, Pos.ToVec3d().Add(0.5, 0.5, 0.5));
+                }
+
+                Api.World.PlaySoundAt(bbhmk.harvestingSound, Pos.X + 0.5, Pos.Y + 0.5, Pos.Z + 0.5);
             }
 
 

--- a/Herbarium/src/BlockEntity/BETallBerryBush.cs
+++ b/Herbarium/src/BlockEntity/BETallBerryBush.cs
@@ -120,6 +120,11 @@ namespace herbarium
                 roomness = 0;
             }
 
+            if (Api.World.Calendar.TotalDays - LastPrunedTotalDays > (5 + rand.NextDouble()) * 1.6 / growthRateMul)
+            {
+                Pruned = false;
+            }
+
             ClimateCondition conds = null;
             float baseTemperature = 0;
             while (daysToCheck > intervalDays)
@@ -180,7 +185,6 @@ namespace herbarium
                 if (transitionHoursLeft <= 0)
                 {
                     if (!DoGrow()) return;
-                    transitionHoursLeft = GetHoursForNextStage();
                 }
             }
 
@@ -190,6 +194,7 @@ namespace herbarium
         public override void OnExchanged(Block block)
         {
             base.OnExchanged(block);
+            transitionHoursLeft = GetHoursForNextStage();
             if (Api?.Side == EnumAppSide.Server) UpdateTransitionsFromBlock();
         }
 
@@ -235,11 +240,6 @@ namespace herbarium
         {
             try
             {
-                if (Api.World.Calendar.TotalDays - LastPrunedTotalDays > Api.World.Calendar.DaysPerYear)
-                {
-                    Pruned = false;
-                }
-
                 Block block = Api.World.BlockAccessor.GetBlock(Pos);
                 string nowCodePart = block.LastCodePart();
                 string nextCodePart = (nowCodePart == "empty") ? "flowering" : ((nowCodePart == "flowering") ? "ripe" : "empty");


### PR DESCRIPTION
There is a bug in the vanilla game that makes it so that when an animal harvests the berries off of the bush the timer is not properly reset.  This fixes that bug in Herbarium by making it so that the game properly resets the timer any time the bush is exchanged.

This also alters the code slightly so that pruned bushes will grow back their branches after 9 days instead of after 1 year.  This is because there is a bug in the base game that makes it so that when you harvest a berry bush the block entity is replaced and it loses the variable showing it was pruned.  I submitted a PR to the vanilla repository that would fix that bug, but with that bug fixed the behavior in Herbarium would need to change slightly.

I chose 9 days arbitrarily, but I don’t expect that to stick.  Instead I imagined that you’d probably want to include a JSON parameter so that the berry bushes could set how long they would take to grow back from being pruned on an individual basis.  I figured once people talked about it for a moment I could just submit a follow up commit and the PR could be merged.

Once this is merged I will update my mod [Berry Bush Fixes](https://mods.vintagestory.at/berrybushfixes) to specifically patch the bug in Vanilla, and then when [the fix](https://github.com/anegostudios/vssurvivalmod/pull/60) is merged into Vanilla a followup PR can be made that makes the necessary changes to this mod directly so it all works seamlessly.