### PR TITLE
Harden block/item attribute reads against missing content-pack config

### DIFF
--- a/Herbarium/HerbariumModSystem.cs
+++ b/Herbarium/HerbariumModSystem.cs
@@ -93,7 +93,7 @@ namespace herbarium
             api.RegisterItemClass("HerbariumPoultice", typeof(HerbariumPoultice));
 
             api.RegisterItemClass("ItemWildTreeSeed", typeof(ItemWildTreeSeed));
-            api.RegisterItemClass("ItemWildShield", typeof(ItemShieldFromAttributes));
+            api.RegisterItemClass("ItemWildShield", typeof(ItemWildShield));
             
             networkHandler.RegisterMessages(api);
             HerbariumConfig.createConfig(api);

--- a/Herbarium/src/Block/BlockLeavesDropCanes.cs
+++ b/Herbarium/src/Block/BlockLeavesDropCanes.cs
@@ -12,17 +12,44 @@ namespace herbarium
 
             if(Attributes["dropsCanes"].AsBool() == true)
             {
-                ItemStack caneItem = new ItemStack(api.World.GetItem(AssetLocation.Create(Attributes["willowCaneItem"].ToString(), Code.Domain)), 1);
-                if(world.Rand.Next(0, 10) > 4) world.SpawnItemEntity(caneItem, pos.ToVec3d());
-
-                //drops.Prepend(caneItem);
+                if(!Attributes["willowCaneItem"].Exists)
+                {
+                    api.Logger.Warning("Herbarium: block {0} has dropsCanes=true but no 'willowCaneItem' attribute; skipping cane drop.", Code);
+                }
+                else
+                {
+                    Item caneItemType = api.World.GetItem(AssetLocation.Create(Attributes["willowCaneItem"].ToString(), Code.Domain));
+                    if(caneItemType == null)
+                    {
+                        api.Logger.Warning("Herbarium: block {0} willowCaneItem '{1}' does not resolve to a known item; skipping cane drop.", Code, Attributes["willowCaneItem"].ToString());
+                    }
+                    else
+                    {
+                        ItemStack caneItem = new ItemStack(caneItemType, 1);
+                        if(world.Rand.Next(0, 10) > 4) world.SpawnItemEntity(caneItem, pos.ToVec3d());
+                    }
+                }
             }
 
             if(Attributes["dropsLeaves"].AsBool() == true)
             {
-                ItemStack leafItem = new ItemStack(api.World.GetItem(AssetLocation.Create(Attributes["leafItem"].ToString(), Code.Domain)), 1);
-                if(world.Rand.Next(0, 10) > 2) world.SpawnItemEntity(leafItem, pos.ToVec3d());
-                //drops.Prepend(leafItem);
+                if(!Attributes["leafItem"].Exists)
+                {
+                    api.Logger.Warning("Herbarium: block {0} has dropsLeaves=true but no 'leafItem' attribute; skipping leaf drop.", Code);
+                }
+                else
+                {
+                    Item leafItemType = api.World.GetItem(AssetLocation.Create(Attributes["leafItem"].ToString(), Code.Domain));
+                    if(leafItemType == null)
+                    {
+                        api.Logger.Warning("Herbarium: block {0} leafItem '{1}' does not resolve to a known item; skipping leaf drop.", Code, Attributes["leafItem"].ToString());
+                    }
+                    else
+                    {
+                        ItemStack leafItem = new ItemStack(leafItemType, 1);
+                        if(world.Rand.Next(0, 10) > 2) world.SpawnItemEntity(leafItem, pos.ToVec3d());
+                    }
+                }
             }
 
             return drops;

--- a/Herbarium/src/Block/DuckWeed.cs
+++ b/Herbarium/src/Block/DuckWeed.cs
@@ -185,6 +185,11 @@ namespace herbarium
                     belowBlock = world.BlockAccessor.GetBlock(pos.DownCopy(currentDepth));
                     if (belowBlock.LiquidCode != "water" && belowBlock.BlockMaterial != EnumBlockMaterial.Plant)
                     {
+                        if (!Attributes["rootBlock"].Exists)
+                        {
+                            api.Logger.Warning("Herbarium: block {0} is missing 'rootBlock' attribute; skipping root placement.", Code);
+                            return;
+                        }
                         Block placingBlock = world.BlockAccessor.GetBlock(new AssetLocation(Attributes["rootBlock"].ToString()));
                         if (placingBlock == null) return;
 
@@ -217,7 +222,17 @@ namespace herbarium
                 if(world.BlockAccessor.GetBlock(newDuckweedPos.DownCopy(), BlockLayersAccess.Fluid).LiquidCode != "water") return; //are we placing in water?
                 if(world.BlockAccessor.GetBlock(newDuckweedPos.DownCopy(growthDepth), BlockLayersAccess.Fluid).LiquidCode == "water") return; //is the water too deep?
 
+                if (!Attributes["duckweedBlock"].Exists)
+                {
+                    api.Logger.Warning("Herbarium: block {0} is missing 'duckweedBlock' attribute; skipping growth.", Code);
+                    return;
+                }
                 Block placingBlock = world.BlockAccessor.GetBlock(new AssetLocation(Attributes["duckweedBlock"].ToString()));
+                if (placingBlock == null)
+                {
+                    api.Logger.Warning("Herbarium: block {0} duckweedBlock '{1}' does not resolve to a known block; skipping growth.", Code, Attributes["duckweedBlock"].ToString());
+                    return;
+                }
                 world.BlockAccessor.SetBlock(placingBlock.BlockId, newDuckweedPos);
             }
         }

--- a/Herbarium/src/Block/GiantKelp.cs
+++ b/Herbarium/src/Block/GiantKelp.cs
@@ -106,8 +106,19 @@ namespace herbarium
         {
             Block aboveBlock = blockAccessor.GetBlock(pos.UpCopy());
 
+            if(!Attributes["middleBlock"].Exists || !Attributes["topBlock"].Exists)
+            {
+                api.Logger.Warning("Herbarium: block {0} is missing 'middleBlock'/'topBlock' attribute(s); skipping kelp placement.", Code);
+                return;
+            }
+
             Block middleBlock = blockAccessor.GetBlock(new AssetLocation(Attributes["middleBlock"].ToString()));
             Block topBlock = blockAccessor.GetBlock(new AssetLocation(Attributes["topBlock"].ToString()));
+            if(middleBlock == null || topBlock == null)
+            {
+                api.Logger.Warning("Herbarium: block {0} middleBlock '{1}' or topBlock '{2}' does not resolve to a known block; skipping kelp placement.", Code, Attributes["middleBlock"].ToString(), Attributes["topBlock"].ToString());
+                return;
+            }
 
             int kelpHeight = worldGenRand.NextInt(kelpMaxHeight) + kelpMinHeight;
 

--- a/Herbarium/src/Block/HerbPlant.cs
+++ b/Herbarium/src/Block/HerbPlant.cs
@@ -89,7 +89,7 @@ namespace herbarium
                 return base.GetDrops(world, pos, byPlayer, dropQuantityMultiplier);
             }
 
-            if(Attributes["hasRoot"].ToString() == "true" && !IsGrown()){
+            if(Attributes["hasRoot"].AsBool(false) && !IsGrown()){
                 return base.GetDrops(world, pos, byPlayer, dropQuantityMultiplier);
             }
             else

--- a/Herbarium/src/Block/HerbariumBerryBush.cs
+++ b/Herbarium/src/Block/HerbariumBerryBush.cs
@@ -138,11 +138,16 @@ namespace herbarium
                     world.PlaySoundAt(harvestingSound, blockSel.Position.X, blockSel.Position.Y, blockSel.Position.Z, byPlayer);
                 }
 
-                clipping = new ItemStack(api.World.GetItem(AssetLocation.Create(this.Attributes["pruneItem"].ToString())), 1);
-                if (clipping is null){
-                    api.Logger.Error("Attempted to create clipping for " + this.Variant["type"] + ", came back null.");
+                if (!this.Attributes["pruneItem"].Exists){
+                    api.Logger.Warning("Herbarium: block {0} is missing 'pruneItem' attribute; cannot create clipping.", Code);
                     return false;
                 }
+                Item pruneItemType = api.World.GetItem(AssetLocation.Create(this.Attributes["pruneItem"].ToString()));
+                if (pruneItemType is null){
+                    api.Logger.Error("Attempted to create clipping for " + this.Variant["type"] + ", pruneItem '" + this.Attributes["pruneItem"].ToString() + "' did not resolve to a known item.");
+                    return false;
+                }
+                clipping = new ItemStack(pruneItemType, 1);
 
                 if (world.Rand.NextDouble() < 0.25)
                 {

--- a/Herbarium/src/Item/ItemWildShield.cs
+++ b/Herbarium/src/Item/ItemWildShield.cs
@@ -1,0 +1,39 @@
+using Newtonsoft.Json.Linq;
+using Vintagestory.API.Common;
+using Vintagestory.API.Datastructures;
+using Vintagestory.GameContent;
+
+namespace herbarium
+{
+    /// <summary>
+    /// Herbarium's shield item. Behaves exactly like vanilla <see cref="ItemShieldFromAttributes"/>,
+    /// but fails soft when a content pack forgets to define the "textures" attribute block.
+    ///
+    /// Vanilla's (private) genTextureSource dereferences Attributes["textures"] without a null check,
+    /// so an itemtype that omits it throws a NullReferenceException the moment the shield is rendered
+    /// (e.g. in the interaction-help HUD). Since that method is private we cannot override it; instead
+    /// we inject an empty "textures" object during OnLoaded. With an empty (rather than missing) block,
+    /// vanilla's texture lookup finds no variant match and falls back to the cached shape textures,
+    /// rendering the base shield instead of crashing the client.
+    /// </summary>
+    public class ItemWildShield : ItemShieldFromAttributes
+    {
+        public override void OnLoaded(ICoreAPI api)
+        {
+            base.OnLoaded(api);
+
+            if (!Attributes["textures"].Exists)
+            {
+                api.Logger.Warning(
+                    "Herbarium: shield item {0} is missing the 'textures' attribute block. " +
+                    "Injecting an empty one so it renders with the base shape textures instead of crashing. " +
+                    "Define attributes.textures (keyed by variant, e.g. \"{{metal}}-{{wood}}\") to give it proper textures.",
+                    Code);
+
+                JObject token = (Attributes?.Token as JObject)?.DeepClone() as JObject ?? new JObject();
+                token["textures"] = new JObject();
+                Attributes = new JsonObject(token);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Two defensive fixes so that content packs which omit expected attributes fail soft (warn + skip) instead of throwing a NullReferenceException and crashing. No behavior change for correctly-configured content.

## 1. Shield render crash when `textures` is missing (`dfa5728`)

`ItemWildShield` was registered directly to vanilla `ItemShieldFromAttributes`, whose private `genTextureSource()` dereferences `Attributes["textures"]` with no null check. A content pack that omits the `textures` block throws an NRE the moment the shield is rendered (e.g. in the interaction-help HUD).

This adds a real `ItemWildShield : ItemShieldFromAttributes` subclass that injects an empty `textures` object in `OnLoaded` when it is absent. With an empty (rather than missing) block, vanilla's lookup finds no variant match and falls back to the cached shape textures, so the shield renders with its base texture instead of crashing the client. A clear warning naming the offending item is logged.

## 2. Guard block attribute reads against missing config (`9b7ef07`)

Several block classes read item/block-code attributes and dereference the result with no `.Exists` check, so a content pack that omits them crashes with an NRE instead of failing gracefully:

- `GiantKelp`: `middleBlock` / `topBlock` (crashes during worldgen)
- `BlockLeavesDropCanes`: `willowCaneItem` / `leafItem`
- `DuckWeed`: `rootBlock` / `duckweedBlock`
- `HerbariumBerryBush`: `pruneItem` (the existing "clipping is null" check never
  fired, since `new ItemStack(null, 1)` is non-null)
- `HerbPlant`: `hasRoot`, via `Attributes["hasRoot"].ToString() == "true"`

Adds `.Exists` / null-resolution guards that log a clear warning and skip the action instead of throwing. `HerbPlant`'s `hasRoot` check is switched to the equivalent, NRE-safe `AsBool(false)`.
